### PR TITLE
Switch to free NLU plan in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 declared-services:
   my-nlu-service:
     label: natural-language-understanding
-    plan: standard
+    plan: free
 
 applications:
 - name: natural-language-understanding-demo


### PR DESCRIPTION
This would make the starter app work out-of-the-box for free tier Bluemix accounts.