### PR TITLE
Update README.md for free plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Natural Language Understanding is a collection of APIs that offer text analysis 
 1. Create and retrieve service keys to access the [Natural Language Understanding][service_url] service:
 
   ```none
-  cf create-service natural-language-understanding standard my-nlu-service
+  cf create-service natural-language-understanding free my-nlu-service
   cf create-service-key my-nlu-service myKey
   cf service-key my-nlu-service myKey
   ```


### PR DESCRIPTION
The instructions for getting the nlp api key refer to the standard plan which is pay-plan.  Change the instructions in the readme to refer to the free plan instead which is more friendly for those using the Bluemix Trial account.  It also matches the free plan specified in the manifest.yml.