### PR TITLE
remove <br /> in description

### DIFF
--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Header, Jumbotron } from 'watson-react-components';
 
 const demoName = 'Natural Language Understanding';
-const DESCRIPTION = 'Natural Language Understanding is a collection of APIs that offer text analysis through natural language processing. This set of APIs can analyze text to help you understand its concepts, entities, keywords, sentiment, and more. Additionally, you can create a custom model for some APIs to get specific results that are tailored to your domain.<br />This system is for demonstration purposes only and is not intended to process Personal Data. No Personal Data is to be entered into this system as it may not have the necessary controls in place to meet the requirements of the General Data Protection Regulation (EU) 2016/679.';
+const DESCRIPTION = 'Natural Language Understanding is a collection of APIs that offer text analysis through natural language processing. This set of APIs can analyze text to help you understand its concepts, entities, keywords, sentiment, and more. Additionally, you can create a custom model for some APIs to get specific results that are tailored to your domain. This system is for demonstration purposes only and is not intended to process Personal Data. No Personal Data is to be entered into this system as it may not have the necessary controls in place to meet the requirements of the General Data Protection Regulation (EU) 2016/679.';
 
 export default function Layout(props) {
   return (


### PR DESCRIPTION
Currently, the `<br />`-tag is not rendered:

![image](https://user-images.githubusercontent.com/5346497/42809845-d25f7e20-89b6-11e8-9249-25920927c15a.png)

This `<br />`-tag was introduced in https://github.com/watson-developer-cloud/natural-language-understanding-nodejs/commit/57db2bac9170f541d52791d0b34cf9b521fa9b7f#diff-a1fbddd013baa04d2bf10aebb02da7ef