### PR TITLE
Fix/aphrodite tags

### DIFF
--- a/views/FloatingCta.jsx
+++ b/views/FloatingCta.jsx
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
     display: 'block',
     opacity: 1,
   },
-  label: {
+  ctalabel: {
     color: '#FFFFFF',
   },
 });
@@ -40,7 +40,7 @@ const FloatingCta = ({
 
   return (
     <a className={combinedVisibleStyles} href={link} rel="noreferrer noopener" target="_blank">
-      <p className={css(styles.label)}>{label}</p>
+      <p className={css(styles.ctalabel)}>{label}</p>
     </a>
   );
 };

--- a/views/FloatingCta.jsx
+++ b/views/FloatingCta.jsx
@@ -5,7 +5,7 @@ import { StyleSheet, css } from 'aphrodite/no-important';
 const styles = StyleSheet.create({
   container: {
     position: 'fixed',
-    bottom: '2rem',
+    bottom: '4rem',
     right: '2rem',
     paddingRight: '3em',
     paddingLeft: '3em',

--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -19,7 +19,7 @@ export default function Layout(props) {
         <link rel="icon" href="/images/favicon.ico" type="image/x-icon" />
         <link rel="stylesheet" href="/css/watson-react-components.min.css" />
         <link rel="stylesheet" href="/css/style.css" />
-        <style date-aphrodite>
+        <style data-aphrodite>
           {css.content}
         </style>
         <script type="text/javascript" src="scripts/bundle.js" defer async />


### PR DESCRIPTION
This fixes a couple small things that appeared in production with the floating CTA tag. Additionally, there was a typo in the data element for the Aphrodite-generated stylesheet, and this fixes that too.

From the Aphrodite docs:

```
<html>
        <head>
            <style data-aphrodite>${css.content}</style>
        </head>
```

The previous tag was `date-aphrodite`