### PR TITLE
fix(manifest): update deprecated buildpack option to buildpacks

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 applications:
 - name: natural-language-understanding-demo
   path: .
-  buildpack: sdk-for-nodejs
+  buildpacks: 
+    - nodejs_buildpack
   command: npm start
   memory: 512M


### PR DESCRIPTION
This is a necessary update to the manifest.yml file in order to deploy